### PR TITLE
Support for JavaScript Decorators

### DIFF
--- a/fixtures/lightning-app/jsconfig.json
+++ b/fixtures/lightning-app/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+      "experimentalDecorators": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -333,6 +333,16 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
+    "@babel/plugin-proposal-decorators": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.12.1.tgz",
+      "integrity": "sha512-knNIuusychgYN8fGJHONL0RbFxLGawhXOJNLBk75TniTsZZeA+wdkDuv6wp4lGwzQEKjZi6/WYtnb3udNPmQmQ==",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-decorators": "^7.12.1"
+      }
+    },
     "@babel/plugin-proposal-dynamic-import": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz",
@@ -446,6 +456,14 @@
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
       "integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-decorators": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.1.tgz",
+      "integrity": "sha512-ir9YW5daRrTYiy9UJ2TzdNIJEZu8KclVzDcfSt4iEmOtwQ4llPtWInNKJyKnVXp1vE4bbVd5S31M/im3mYMO1w==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.11.6",
+    "@babel/plugin-proposal-decorators": "^7.12.1",
     "@babel/plugin-transform-parameters": "^7.10.5",
     "@babel/plugin-transform-spread": "^7.11.0",
     "@babel/preset-env": "^7.11.5",

--- a/src/configs/rollup.es5.config.js
+++ b/src/configs/rollup.es5.config.js
@@ -23,6 +23,7 @@ const babel = require('@rollup/plugin-babel').babel
 const resolve = require('@rollup/plugin-node-resolve').nodeResolve
 const commonjs = require('@rollup/plugin-commonjs')
 const babelPresentEnv = require('@babel/preset-env')
+const babelPluginProposalDecorators = require('@babel/plugin-proposal-decorators')
 const babelPluginTransFormSpread = require('@babel/plugin-transform-spread')
 const babelPluginTransFormParameters = require('@babel/plugin-transform-parameters')
 const alias = require('@rollup/plugin-alias')
@@ -58,7 +59,6 @@ module.exports = {
       },
     }),
     resolve({ mainFields: ['module', 'main', 'browser'] }),
-    commonjs({ sourceMap: false }),
     babel({
       presets: [
         [
@@ -74,8 +74,13 @@ module.exports = {
           },
         ],
       ],
-      plugins: [babelPluginTransFormSpread, babelPluginTransFormParameters],
+      plugins: [
+        [babelPluginProposalDecorators, { legacy: true }],
+        babelPluginTransFormSpread,
+        babelPluginTransFormParameters,
+      ],
     }),
+    commonjs({ sourceMap: false }),
     (process.env.LNG_BUILD_MINIFY === 'true' || process.env.NODE_ENV === 'production') &&
       minify({ keep_fnames: true }),
     license({

--- a/src/configs/rollup.es6.config.js
+++ b/src/configs/rollup.es6.config.js
@@ -19,8 +19,11 @@
 
 const path = require('path')
 const process = require('process')
+const babel = require('@rollup/plugin-babel').babel
 const resolve = require('@rollup/plugin-node-resolve').nodeResolve
 const commonjs = require('@rollup/plugin-commonjs')
+const babelPresentEnv = require('@babel/preset-env')
+const babelPluginProposalDecorators = require('@babel/plugin-proposal-decorators')
 const alias = require('@rollup/plugin-alias')
 const json = require('@rollup/plugin-json')
 const virtual = require('@rollup/plugin-virtual')
@@ -54,6 +57,9 @@ module.exports = {
       },
     }),
     resolve({ mainFields: ['module', 'main', 'browser'] }),
+    babel({
+      plugins: [[babelPluginProposalDecorators, { legacy: true }]],
+    }),
     commonjs({ sourceMap: false }),
     (process.env.LNG_BUILD_MINIFY === 'true' || process.env.NODE_ENV === 'production') &&
       minify({ keep_fnames: true }),


### PR DESCRIPTION
## Feature
Add support for using JavaScript decorators

### Solution
- Add `@babel/plugin-proposal-decorators` as a dependency
- Include the plugin as part of the babel plugins block in es5 & es6 rollup configs. This required me to move the babel block ahead of the commonjs block as commonjs was complaining about unknown `@` symbols.
- Add `jsconfig.json` inside fixtures/lightning-app to prevent VS Code complaining about the use of decorators.

### Usage

Here's a very contrived example;

```js
import { Lightning } from '@lightningjs/sdk'

import { sayHello } from './sayHello'

@sayHello('lightning')
export class MyComponent extends Lightning.Component {
  static _template() {
    return {
      Background: {
        w: 1920,
        h: 1080,
        color: 0xffCC0000,
        rect: true,
      },
    }
  }
}
```

```js
export const sayHello = (name) => (target) => {
  console.log('hello', name)
  return target
}
```