### PR TITLE
Add support for monorepos

### DIFF
--- a/src/helpers/build.js
+++ b/src/helpers/build.js
@@ -27,12 +27,12 @@ const os = require('os')
 const esbuild = require('esbuild')
 const spinner = require('./spinner')
 
-const findFolder = (parent, folderPath) => {
-  const fullPath = path.join(parent, folderPath)
+const findFile = (parent, filePath) => {
+  const fullPath = path.join(parent, filePath)
   if (fs.existsSync(fullPath)) {
     return fullPath
   }
-  return findFolder(path.join(parent, '..'), folderPath)
+  return findFile(path.join(parent, '..'), filePath)
 }
 
 const removeFolder = folder => {
@@ -48,15 +48,13 @@ const ensureFolderExists = folder => {
 }
 
 const copySupportFiles = folder => {
-  console.log('WIBBLE')
-
   spinner.start('Copying support files to "' + folder.split('/').pop() + '"')
 
   const nodeModulesPath = hasNewSDK()
     ? 'node_modules/@lightningjs/sdk'
     : 'node_modules/wpe-lightning-sdk'
 
-  const lightningSDKfolder = findFolder(process.cwd(), nodeModulesPath)
+  const lightningSDKfolder = findFile(process.cwd(), nodeModulesPath)
 
   shell.cp('-r', path.join(lightningSDKfolder, 'support/*'), folder)
 
@@ -323,7 +321,8 @@ const getSdkVersion = () => {
   const packagePath = hasNewSDK()
     ? 'node_modules/@lightningjs/sdk'
     : 'node_modules/wpe-lightning-sdk'
-  return require(path.join(process.cwd(), packagePath, 'package.json')).version
+  const packageJsonPath = findFile(process.cwd(), packagePath)
+  return require(path.join(packageJsonPath, 'package.json')).version
 }
 
 const getCliVersion = () => {

--- a/src/helpers/build.js
+++ b/src/helpers/build.js
@@ -27,6 +27,14 @@ const os = require('os')
 const esbuild = require('esbuild')
 const spinner = require('./spinner')
 
+const findFolder = (parent, folderPath) => {
+  const fullPath = path.join(parent, folderPath)
+  if (fs.existsSync(fullPath)) {
+    return fullPath
+  }
+  return findFolder(path.join(parent, '..'), folderPath)
+}
+
 const removeFolder = folder => {
   spinner.start('Removing "' + folder.split('/').pop() + '" folder')
   shell.rm('-rf', folder)
@@ -40,13 +48,17 @@ const ensureFolderExists = folder => {
 }
 
 const copySupportFiles = folder => {
+  console.log('WIBBLE')
+
   spinner.start('Copying support files to "' + folder.split('/').pop() + '"')
 
-  if (hasNewSDK()) {
-    shell.cp('-r', path.join(process.cwd(), 'node_modules/@lightningjs/sdk/support/*'), folder)
-  } else {
-    shell.cp('-r', path.join(process.cwd(), 'node_modules/wpe-lightning-sdk/support/*'), folder)
-  }
+  const nodeModulesPath = hasNewSDK()
+    ? 'node_modules/@lightningjs/sdk'
+    : 'node_modules/wpe-lightning-sdk'
+
+  const lightningSDKfolder = findFolder(process.cwd(), nodeModulesPath)
+
+  shell.cp('-r', path.join(lightningSDKfolder, 'support/*'), folder)
 
   const command = process.argv.pop()
 


### PR DESCRIPTION
Pull request to fix https://github.com/rdkcentral/Lightning-CLI/issues/106

Lightning CLI makes assumptions that `node_modules` is in the same directory as the applications `package.json` file. In most cases this is true but for monorepos, all `node_modules` are hoisted into the monorepo root. This means Lightning CLI fails to build the project.

This pull request adds a function inside `helpers/build.js` to recursively search for the Lightning SDK in parent directories. It doesn't break the existing behaviour and works with ES5 & ES6 builds.