### PR TITLE
added support for process.env.NODE_ENV in esbuild configs

### DIFF
--- a/src/configs/esbuild.es5.config.js
+++ b/src/configs/esbuild.es5.config.js
@@ -37,6 +37,8 @@ module.exports = (folder, globalName) => {
     acc[`process.env.${key}`] = `"${appVars[key]}"`
     return acc
   }, {})
+  // for process.env.NODE_ENV
+  defined['process.env.NODE_ENV'] = `"${process.env.NODE_ENV}"`
 
   return {
     plugins: [

--- a/src/configs/esbuild.es6.config.js
+++ b/src/configs/esbuild.es6.config.js
@@ -37,6 +37,8 @@ module.exports = (folder, globalName) => {
     acc[`process.env.${key}`] = `"${appVars[key]}"`
     return acc
   }, {})
+  // for process.env.NODE_ENV
+  defined['process.env.NODE_ENV'] = `"${process.env.NODE_ENV}"`
 
   return {
     plugins: [


### PR DESCRIPTION
Similar to `rollup.config`, added support for `process.env.NODE_ENV` in esbuild config.
```javascript
// rollup.config.js
processEnv: `export default ${JSON.stringify({
  NODE_ENV: process.env.NODE_ENV,
  ...buildHelpers.getEnvAppVars(dotenv.parsed),
})}`,
```
Many third-party modules like `redux` rely on NODE_ENV. Currently, bundling with esbuild throws an error because of `NODE_ENV`.