### PR TITLE
added process.env.NODE_ENV support esbuild

### DIFF
--- a/src/configs/esbuild.es5.config.js
+++ b/src/configs/esbuild.es5.config.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ module.exports = (folder, globalName) => {
     acc[`process.env.${key}`] = `"${appVars[key]}"`
     return acc
   }, {})
+  defined['process.env.NODE_ENV'] = `"${process.env.NODE_ENV}"`
 
   return {
     plugins: [

--- a/src/configs/esbuild.es6.config.js
+++ b/src/configs/esbuild.es6.config.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ module.exports = (folder, globalName) => {
     acc[`process.env.${key}`] = `"${appVars[key]}"`
     return acc
   }, {})
+  defined['process.env.NODE_ENV'] = `"${process.env.NODE_ENV}"`
 
   return {
     plugins: [


### PR DESCRIPTION
Similar to `rollup.config`, added support for `process.env.NODE_ENV` in esbuild config.
```javaScript
// rollup.config.js
processEnv: `export default ${JSON.stringify({
  NODE_ENV: process.env.NODE_ENV,
  ...buildHelpers.getEnvAppVars(dotenv.parsed),
})}`,
```
Many third-party modules like `redux` rely on NODE_ENV. Currently, bundling with esbuild throws an error because of NODE_ENV.