### PR TITLE
Added process.exit and changed console.log to console.error in build …

### DIFF
--- a/src/actions/dist.js
+++ b/src/actions/dist.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 const path = require('path')
 const fs = require('fs')
 const sequence = require('../helpers/sequence')
@@ -66,6 +66,8 @@ module.exports = types => {
       .then(function() {
         return dist(type)
       })
-      .catch(Promise.reject)
+      .catch(() => {
+        process.exit(1)
+      })
   }, Promise.resolve(null))
 }

--- a/src/helpers/build.js
+++ b/src/helpers/build.js
@@ -168,7 +168,7 @@ const buildAppEsBuild = async (folder, metadata, type) => {
     return metadata
   } catch (e) {
     spinner.fail(`Error while creating ${type.toUpperCase()} bundle using [esbuild] (see log)`)
-    console.log(e.stderr)
+    console.error(e.stderr)
     throw Error(e)
   }
 }
@@ -197,7 +197,7 @@ const bundleAppRollup = (folder, metadata, type, options) => {
     })
     .catch(e => {
       spinner.fail(`Error while creating ${type.toUpperCase()} bundle (see log)`)
-      console.log(e.stderr)
+      console.error(e.stderr)
       throw Error(e)
     })
 }


### PR DESCRIPTION
Hello,

We had an issue last week that made us realize that our CI was not failing builds when the CLI was unable to generate the application bundle (via `dist`) due to a build error. 

### Context

Development is on Mac and Windows, our CLI/Pipeline runs on Azure DevOps and builds a Docker containers (Linux). The error that generated a CLI build failure was a case mismatch in an import statement. Once we realized that the CLI was not generating the bundle we could not reproduce the issue on dev environments since only Linux is case sensitive. 

The following PR is a patch we are currently applying to the CLI sources in our CI pipeline before we start the build process. 

### The CLI fails "silently" 

The first issue is that the build did not fail when the CLI was unable to generate the application bundle. Hence the `process.exit(1)` we added. We can argue as to where we put this (`bundleEs6App`, `bundleEs5App` would be more appropriate ?) but we think the process should exit stating that an error occurred (code 1) when the sources cannot be built so that CI integrations can also fail properly. 

### The error displayed was not relevant 

The second issue was that the error displayed was not relevant at all: 

<img width="1716" alt="Capture d’écran, le 2021-07-26 à 10 31 42" src="https://user-images.githubusercontent.com/87981092/127006578-b57a4b23-31d2-4935-8147-4ff16d9a6b7c.png">

We found that using `console.error()` in catch statements made the proper error render in the CI logs.

