### PR TITLE
Addressed CLI Issue 160 - Make default value for App identifier match App name

### DIFF
--- a/src/actions/create.js
+++ b/src/actions/create.js
@@ -37,10 +37,13 @@ const askAppName = () =>
     appName => validateAppName(appName),
   ])
 
-const askAppId = () =>
+const askAppId = appName =>
   sequence([
     () =>
-      ask('What is the App identifier? (reverse-DNS format)', 'com.metrological.app.myawesomeapp'),
+      ask(
+        'What is the App identifier? (reverse-DNS format)',
+        `com.metrological.app.${appName.replace(/ +/g, '').toLowerCase()}`
+      ),
     appId => validateAppId(appId),
   ])
 
@@ -76,7 +79,7 @@ const askConfig = () => {
   const config = {}
   return sequence([
     () => askAppName().then(appName => (config.appName = appName)),
-    () => askAppId().then(appId => (config.appId = appId)),
+    () => askAppId(config.appName).then(appId => (config.appId = appId)),
     () => askAppFolder(config.appId).then(folder => (config.appFolder = folder)),
     () => askESlint().then(eslint => (config.eslint = eslint)),
     () => config,


### PR DESCRIPTION
Made default value for App identifier match App name

This will address the https://github.com/rdkcentral/Lightning-CLI/issues/160