### PR TITLE
Adding documentation changes from the website

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
-- [Installation](installation.md)
-- [Available commands](availablecommands.md)
+- [Installation](installation/index.md)
+- [Commands](commands/index.md)
   - [Create](commands/create.md)
   - [Build](commands/build.md)
   - [Serve](commands/serve.md)

--- a/docs/environmentvariables.md
+++ b/docs/environmentvariables.md
@@ -48,6 +48,7 @@ You can use the following environment variables to customize the behavior of the
 | `LNG_AUTO_UPDATE` | true | Indicates whether or not the Lightning CLI should automatically update ('auto update'). Possible values: `true`, `false`. **Note**: It is recommended to keep auto updates enabled. |
 | `LNG_BUILD_EXIT_ON_FAIL` | false | Specifies whether or not the build process should hard exit when a build error occurs. Note that the build process is triggered in several commands (`lng build`, `lng dev`, `lng watch` and `lng dist`) |
 | `LNG_BUILD_FAIL_ON_WARNINGS` | false | Specifies whether or not to show the warning to the user when a build warning occurs. Note that the build process is triggered in several commands (`lng build`, `lng dev`, `lng watch` and `lng dist`) |
+| `LNG_BUNDLER` | rollup | Specify which bundler the CLI should use to bundle the app.  Possible values: `rollup`, `esbuild`. |
 
 #### `LNG_SETTINGS_ENV`
 Specifies which environment to be used. User need to have `settings.{env}.json` file in the Project home folder with different settings. This will build/dist the application with `settings.{env}.json`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,17 @@
 
 The Reference Documentation for Lightning CLI contains detailed descriptions of:
 
-* [Install the Lighting CLI](installation/index.md)
-* [CLI Commands](commands/index.md)
+<!---TOC_start--->
+* [Installation](installation/index.md)
+* [Commands](commands/index.md)
+  * [Create](commands/create.md)
+  * [Build](commands/build.md)
+  * [Serve](commands/serve.md)
+  * [Watch](commands/watch.md)
+  * [Dev](commands/dev.md)
+  * [Docs](commands/docs.md)
+  * [Dist](commands/dist.md)
+  * [Upload](commands/upload.md)
+  * [Update](commands/update.md)
 * [Environment Variables](environmentvariables.md)
+<!---TOC_end--->


### PR DESCRIPTION
- adds changes done on the Lightning website regarding the documentation (tried to preserve original commit 9b001839fcd7b8a754cf9e1a8d26d94f901ca131 pushed by @erikhaandrikman)
- adds an updated _table of contents_ section to the main `index.md` file
- markdown comments (`TOC_start` and `TOC_end`) added to the `index.md` file will be used for parsing that section while generating documentation on the website.
- fixed `_sidebar.md` file for GitHub pages website.