### PR TITLE
Dedupe lightning sdk and ui dependencies

### DIFF
--- a/src/configs/rollup.es5.config.js
+++ b/src/configs/rollup.es5.config.js
@@ -65,7 +65,11 @@ module.exports = {
         '~': path.resolve(process.cwd(), 'node_modules/'),
       },
     }),
-    resolve({ extensions, mainFields: ['module', 'main', 'browser'] }),
+    resolve({
+      extensions,
+      mainFields: ['module', 'main', 'browser'],
+      dedupe: ['@lightningjs/sdk', '@lightningjs/ui'],
+    }),
     commonjs({ sourceMap: false }),
     babel({
       presets: [

--- a/src/configs/rollup.es6.config.js
+++ b/src/configs/rollup.es6.config.js
@@ -62,7 +62,11 @@ module.exports = {
         '~': path.resolve(process.cwd(), 'node_modules/'),
       },
     }),
-    resolve({ extensions, mainFields: ['module', 'main', 'browser'] }),
+    resolve({
+      extensions,
+      mainFields: ['module', 'main', 'browser'],
+      dedupe: ['@lightningjs/sdk', '@lightningjs/ui'],
+    }),
     commonjs({ sourceMap: false }),
     babel({
       presets: [[babelPresetTypescript]],


### PR DESCRIPTION
In a monorepo setup I ran into issues of especially LightningSDK being included multiple times. This resulted into multiple instances of the Router object and other references, that should only exist once. By deduping them in the bundle (Rollup), this issue does not happen anymore.

Example repo packages that you'll need to verify this:
```
- app
- - lightningjs/sdk
- - customwidgets (lerna or yarn/npm workspaces to resolve local package)
- customwidgets
- - lightningjs/sdk
```