### PR TITLE
Added safari 12.0 as target for esbuild and rollup es6 config files

### DIFF
--- a/src/configs/esbuild.es6.config.js
+++ b/src/configs/esbuild.es6.config.js
@@ -22,6 +22,7 @@ const os = require('os')
 const alias = require('../plugins/esbuild-alias')
 const babel = require('../helpers/esbuildbabel')
 const babelPresetTypescript = require('@babel/preset-typescript')
+const babelPresetEnv = require('@babel/preset-env')
 const path = require('path')
 const dotenv = require('dotenv')
 const babelPluginClassProperties = require('@babel/plugin-proposal-class-properties')
@@ -67,7 +68,17 @@ module.exports = (folder, globalName) => {
       ]),
       babel({
         config: {
-          presets: [babelPresetTypescript],
+          presets: [
+            [
+              babelPresetEnv,
+              {
+                targets: {
+                  safari: '12.0',
+                },
+              },
+            ],
+            [babelPresetTypescript],
+          ],
           plugins: [babelPluginClassProperties, babelPluginInlineJsonImport],
         },
       }),

--- a/src/configs/rollup.es6.config.js
+++ b/src/configs/rollup.es6.config.js
@@ -22,6 +22,7 @@ const process = require('process')
 const babel = require('@rollup/plugin-babel').babel
 const babelPluginClassProperties = require('@babel/plugin-proposal-class-properties')
 const babelPresetTypescript = require('@babel/preset-typescript')
+const babelPresetEnv = require('@babel/preset-env')
 const resolve = require('@rollup/plugin-node-resolve').nodeResolve
 const commonjs = require('@rollup/plugin-commonjs')
 const alias = require('@rollup/plugin-alias')
@@ -65,7 +66,17 @@ module.exports = {
     resolve({ extensions, mainFields: ['module', 'main', 'browser'] }),
     commonjs({ sourceMap: false }),
     babel({
-      presets: [[babelPresetTypescript]],
+      presets: [
+        [
+          babelPresetEnv,
+          {
+            targets: {
+              safari: '12.0',
+            },
+          },
+        ],
+        [babelPresetTypescript],
+      ],
       extensions,
       babelHelpers: 'bundled',
       plugins: [babelPluginClassProperties],


### PR DESCRIPTION
Added safari 12.0 as a target for esbuild and rollup es6 config files