### PR TITLE
Fix es5 polyfill path

### DIFF
--- a/src/helpers/build.js
+++ b/src/helpers/build.js
@@ -238,10 +238,12 @@ const bundlePolyfills = folder => {
   spinner.start('Bundling ES5 polyfills and saving to "' + folder.split('/').pop() + '"')
 
   const nodeModulesPath = hasNewSDK()
-    ? path.join(process.cwd(), 'node_modules/@lightningjs/sdk')
-    : path.join(process.cwd(), 'node_modules/wpe-lightning-sdk/')
+    ? 'node_modules/@lightningjs/sdk'
+    : 'node_modules/wpe-lightning-sdk'
 
-  const pathToPolyfills = path.join(nodeModulesPath, 'support/polyfills')
+  const lightningSDKfolder = findFile(process.cwd(), nodeModulesPath)
+
+  const pathToPolyfills = path.join(lightningSDKfolder, 'support/polyfills')
 
   const polyfills = fs.readdirSync(pathToPolyfills).map(file => path.join(pathToPolyfills, file))
 


### PR DESCRIPTION
Fixes a left-over from a rewrite to support monorepos that has been implemented here: https://github.com/rdkcentral/Lightning-CLI/pull/154