### PR TITLE
Added --es5 and --es6 option to build

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -56,12 +56,21 @@ program
 
 program
   .command('build')
+  .option('--es5', 'Build standalone ES5 version of the App')
+  .option('--es6', 'Build standalone ES6 version of the App')
   .description(
     ['👷‍♂️', ' '.repeat(3), 'Build a local development version of the Lightning App'].join('')
   )
-  .action(() => {
+  .action(options => {
+    const input = options.opts()
+    const defaultTypes = ['default']
+
+    const selectedTypes = Object.keys(input)
+      .map(type => input[type] === true && type.toLocaleLowerCase())
+      .filter(val => !!val)
+
     updateCheck()
-      .then(() => buildAction(true))
+      .then(() => buildAction(true, null, selectedTypes.length ? selectedTypes : defaultTypes))
       .catch(e => {
         console.error(e)
         process.exit(1)


### PR DESCRIPTION
Added options to build command to build es5 es6 or both.
`lng build --es5 --es6`
If options are used it overrules settings.platformSettings.esEnv
when used without options it works as before