### PR TITLE
Preserve Symbolic Links in the build process

### DIFF
--- a/src/helpers/build.js
+++ b/src/helpers/build.js
@@ -204,6 +204,7 @@ const bundleAppRollup = (folder, metadata, type, options) => {
     path.join(folder, type === 'es6' ? 'appBundle.js' : 'appBundle.es5.js'),
     '--name',
     makeSafeAppId(metadata),
+    '--preserveSymlinks',
   ]
 
   if (options.sourcemaps === false) args.push('--no-sourcemap')


### PR DESCRIPTION
For a parallel testing scenario, in MacOS, if we use symbolic link of the main project in the tests, in the build process, these folders are considered as a separate module.

Adding --preserveSymlinks to the rollup process solves the problem.

Do you consider this a good solution or advise something different?