### PR TITLE
Added fix for supporting func names in esbuild config

### DIFF
--- a/src/configs/esbuild.es5.config.js
+++ b/src/configs/esbuild.es5.config.js
@@ -97,6 +97,7 @@ module.exports = (folder, globalName) => {
     minifyWhitespace: minify,
     minifyIdentifiers: minify,
     minifySyntax: false,
+    keepNames: minify,
     entryPoints: [`${process.cwd()}/src/index.js`],
     bundle: true,
     target: 'es5',

--- a/src/configs/esbuild.es6.config.js
+++ b/src/configs/esbuild.es6.config.js
@@ -87,6 +87,7 @@ module.exports = (folder, globalName) => {
     minifyWhitespace: minify,
     minifyIdentifiers: minify,
     minifySyntax: false,
+    keepNames: minify,
     entryPoints: [`${process.cwd()}/src/index.js`],
     bundle: true,
     outfile: `${folder}/appBundle.js`,


### PR DESCRIPTION
Added support for showing func names in esbuild bundle
Fix for 
https://github.com/rdkcentral/Lightning-CLI/issues/213