### PR TITLE
fix #226: remove license from app files

### DIFF
--- a/fixtures/js/lightning-app/src/App.js
+++ b/fixtures/js/lightning-app/src/App.js
@@ -1,22 +1,3 @@
-/*
- * If not stated otherwise in this file or this component's LICENSE file the
- * following copyright and licenses apply:
- *
- * Copyright 2020 Metrological
- *
- * Licensed under the Apache License, Version 2.0 (the License);
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import { Lightning, Utils } from '@lightningjs/sdk'
 
 export default class App extends Lightning.Component {

--- a/fixtures/ts/lightning-app/src/App.ts
+++ b/fixtures/ts/lightning-app/src/App.ts
@@ -1,21 +1,3 @@
-/*
- * If not stated otherwise in this file or this component's LICENSE file the
- * following copyright and licenses apply:
- *
- * Copyright 2022 Metrological
- *
- * Licensed under the Apache License, Version 2.0 (the License);
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 import { Lightning, Utils } from '@lightningjs/sdk'
 
 interface AppTemplateSpec extends Lightning.Component.TemplateSpec {


### PR DESCRIPTION
App files are copied to new projects using `lng create` which shouldn't include License info.