### PR TITLE
Fix/esbuild sourcemap

### DIFF
--- a/src/configs/esbuild.es5.config.js
+++ b/src/configs/esbuild.es5.config.js
@@ -103,7 +103,7 @@ module.exports = (folder, globalName) => {
     target: 'es5',
     mainFields: buildHelpers.getResolveConfigForBundlers(),
     outfile: `${folder}/appBundle.es5.js`,
-    sourcemap: sourcemap,
+    sourcemap,
     format: 'iife',
     define: defined,
     globalName,

--- a/src/configs/esbuild.es5.config.js
+++ b/src/configs/esbuild.es5.config.js
@@ -31,11 +31,13 @@ const babelPluginInlineJsonImport = require('babel-plugin-inline-json-import')
 
 module.exports = (folder, globalName) => {
   const sourcemap =
-    process.env.LNG_BUILD_SOURCEMAP === 'true'
-      ? true
+    process.env.NODE_ENV === 'production'
+      ? 'external'
       : process.env.LNG_BUILD_SOURCEMAP === 'inline'
       ? 'inline'
-      : false
+      : process.env.LNG_BUILD_SOURCEMAP === 'false'
+      ? ''
+      : 'external'
 
   // Load .env config every time build is triggered
   const appVars = {
@@ -101,7 +103,7 @@ module.exports = (folder, globalName) => {
     target: 'es5',
     mainFields: buildHelpers.getResolveConfigForBundlers(),
     outfile: `${folder}/appBundle.es5.js`,
-    sourcemap,
+    sourcemap: sourcemap,
     format: 'iife',
     define: defined,
     globalName,

--- a/src/configs/esbuild.es6.config.js
+++ b/src/configs/esbuild.es6.config.js
@@ -29,11 +29,13 @@ const babelPluginInlineJsonImport = require('babel-plugin-inline-json-import')
 
 module.exports = (folder, globalName) => {
   const sourcemap =
-    process.env.LNG_BUILD_SOURCEMAP === 'true'
-      ? true
+    process.env.NODE_ENV === 'production'
+      ? 'external'
       : process.env.LNG_BUILD_SOURCEMAP === 'inline'
       ? 'inline'
-      : false
+      : process.env.LNG_BUILD_SOURCEMAP === 'false'
+      ? ''
+      : 'external'
 
   //Load .env config every time build is triggered
   const appVars = {

--- a/src/configs/esbuild.es6.config.js
+++ b/src/configs/esbuild.es6.config.js
@@ -92,7 +92,7 @@ module.exports = (folder, globalName) => {
     bundle: true,
     outfile: `${folder}/appBundle.js`,
     mainFields: buildHelpers.getResolveConfigForBundlers(),
-    sourcemap,
+    sourcemap: sourcemap,
     format: 'iife',
     define: defined,
     target: process.env.LNG_BUNDLER_TARGET || '',

--- a/src/configs/esbuild.es6.config.js
+++ b/src/configs/esbuild.es6.config.js
@@ -92,7 +92,7 @@ module.exports = (folder, globalName) => {
     bundle: true,
     outfile: `${folder}/appBundle.js`,
     mainFields: buildHelpers.getResolveConfigForBundlers(),
-    sourcemap: sourcemap,
+    sourcemap,
     format: 'iife',
     define: defined,
     target: process.env.LNG_BUNDLER_TARGET || '',

--- a/src/configs/rollup.es5.config.js
+++ b/src/configs/rollup.es5.config.js
@@ -116,6 +116,13 @@ module.exports = {
   output: {
     format: 'iife',
     inlineDynamicImports: true,
-    sourcemap: true,
+    sourcemap:
+      process.env.NODE_ENV === 'production'
+        ? true
+        : process.env.LNG_BUILD_SOURCEMAP === undefined
+        ? true
+        : process.env.LNG_BUILD_SOURCEMAP === 'false'
+        ? false
+        : process.env.LNG_BUILD_SOURCEMAP,
   },
 }


### PR DESCRIPTION
Following are the changes that are done in this PR : 
1. Fixed the default behavior of esbuild for building sourcemap for both es5 and es6 version. For esbuild sourcemap refer the below link : https://esbuild.github.io/api/#sourcemap
2. Fixed default behavior of rollup for building sourcemap for es5 version.