### PR TITLE
Add "include" config in `lng create` tsconfig.json

### DIFF
--- a/fixtures/ts/lightning-app/tsconfig.json
+++ b/fixtures/ts/lightning-app/tsconfig.json
@@ -7,5 +7,6 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true
-  }
+  },
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Without this, TypeScript's `tsc` attempts to compile all TS files that are present in the App's directory structure. It should only compile TS files from the `src` folder.