### PR TITLE
Updated code to fix dist issue with env in settings file

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -152,7 +152,7 @@ program
   .action(options => {
     const input = options.opts()
 
-    const defaultTypes = ['es6']
+    const defaultTypes = ['defaults']
     const isWatchEnabled = input.watch ? input.watch : false
     delete input.watch
 

--- a/src/actions/dist.js
+++ b/src/actions/dist.js
@@ -32,7 +32,7 @@ module.exports = options => {
   let settings
 
   const buildES = (type, esEnv) => {
-    return type === esEnv || esEnv === undefined
+    return !!(type || esEnv)
   }
 
   const dist = (type, config) => {
@@ -42,6 +42,13 @@ module.exports = options => {
       () => distHelpers.moveOldDistFolderToBuildFolder(),
       () => buildHelpers.ensureCorrectGitIgnore(),
       () => buildHelpers.readMetadata().then(result => (metadata = result)),
+      () => buildHelpers.readSettings(settingsFileName).then(result => (settings = result)),
+      () =>
+        (type = !type.includes('defaults')
+          ? type
+          : settings.platformSettings.esEnv
+          ? settings.platformSettings.esEnv
+          : 'es6'),
       () => {
         distDir = path.join(baseDistDir, type)
       },
@@ -57,7 +64,6 @@ module.exports = options => {
       },
       () => buildHelpers.removeFolder(path.join(distDir, 'static')),
       () => buildHelpers.copyStaticFolder(distDir),
-      () => buildHelpers.readSettings(settingsFileName).then(result => (settings = result)),
       () =>
         type === 'es6' &&
         buildES('es6', settings.platformSettings.esEnv) &&


### PR DESCRIPTION
Following are the scenarios that are verified using the fix:

I have verified this with below cases :

**With no esEnv setting in setings.json file**
lng dist :  Creates dist version of es6 
lng dist --es6 : Creates dist version of es6
lng dist --es5: Created dist version of es5
lng dist --es5 --es6 : Creates both es5 and es6

**With esEnv setting in setings.json file**
lng dist & esEnv:es5 :  Creates dist version of es5
lng dist & esEnv:es6 :  Creates dist version of es5
lng dist --<es5/es6> & esEnv:es5 :  Creates dist version of es5/es6 and ignores the settings.json file esEnv

**With different settings file(for ex: settings.es5.json)**
lng dist & esEnv:es5 :  Creates dist version of es5
lng dist & esEnv:es6 :  Creates dist version of es5
lng dist --<es5/es6> & esEnv:es5 :  Creates dist version of es5/es6 and ignores the settings.json file esEnv
