### PR TITLE
Added .mjs extension to rollup config for transpiling(es5)

### DIFF
--- a/src/configs/rollup.es5.config.js
+++ b/src/configs/rollup.es5.config.js
@@ -38,7 +38,7 @@ const buildHelpers = require(path.join(__dirname, '../helpers/build'))
 const minify = require('rollup-plugin-terser').terser
 const license = require('rollup-plugin-license')
 const os = require('os')
-const extensions = ['.js', '.ts']
+const extensions = ['.js', '.ts', '.mjs']
 
 module.exports = {
   onwarn(warning, warn) {


### PR DESCRIPTION
To transpile the Firebolt sdk module( containing .mjs files ) to es5, adding the .mjs extension in rollup extensions array